### PR TITLE
Add Timing Information to OSV Vulnerability Data

### DIFF
--- a/ossrepo-backend/src/features/packages/services/osv-vulnerability.service.ts
+++ b/ossrepo-backend/src/features/packages/services/osv-vulnerability.service.ts
@@ -8,6 +8,8 @@ export interface OsvVulnerability {
   details?: string;
   affected_versions?: string[];
   references?: { type: string; url: string }[];
+  published?: Date;    // When vulnerability was first published
+  modified?: Date;     // When vulnerability was last updated
 }
 
 @Injectable()
@@ -26,7 +28,9 @@ export class OsvVulnerabilityService {
         severity: vuln.severity?.[0]?.type ? `${vuln.severity[0].type}: ${vuln.severity[0].score}` : undefined,
         details: vuln.details,
         affected_versions: vuln.affected?.flatMap((a: any) => a.ranges?.flatMap((r: any) => r.events?.map((e: any) => e.introduced || e.fixed || e.last_affected || e.limit)).filter(Boolean)) || [],
-        references: vuln.references || []
+        references: vuln.references || [],
+        published: vuln.published ? new Date(vuln.published) : undefined,
+        modified: vuln.modified ? new Date(vuln.modified) : undefined
       }));
     } catch (e) {
       return [];


### PR DESCRIPTION
# Add Timing Information to OSV Vulnerability Data

## Problem
Team feedback identified missing timing information in vulnerability data. Users needed to know "when CVE happened" to assess whether vulnerabilities are active or historical.

## Solution
Added `published` and `modified` fields to OSV vulnerability interface and service to capture timing information from OSV.dev API.

## Changes Made

### Modified Files
- **`src/features/packages/services/osv-vulnerability.service.ts`**
  - Added `published?: Date` and `modified?: Date` to `OsvVulnerability` interface
  - Updated mapping to extract timing fields from OSV API response
  - Converts ISO string dates to proper Date objects

- **`docs/packages/osv_vulnerability_integration.md`**
  - Updated interface documentation to include timing fields
  - Added timing examples in API response samples
  - Updated service responsibilities to mention timing extraction

### Technical Details
```typescript
// Enhanced interface
export interface OsvVulnerability {
  id: string;
  summary: string;
  severity?: string;
  details?: string;
  affected_versions?: string[];
  references?: { type: string; url: string }[];
  published?: Date;    // When vulnerability was first published
  modified?: Date;     // When vulnerability was last updated
}

// Enhanced mapping
return res.data.vulns.map((vuln: any) => ({
  // ... existing fields ...
  published: vuln.published ? new Date(vuln.published) : undefined,
  modified: vuln.modified ? new Date(vuln.modified) : undefined
}));
```

## Benefits
- **Timing Context**: Users can see when vulnerabilities were discovered and last updated
- **Data Freshness**: Clear indication of vulnerability information recency
- **Active vs Historical**: Ability to assess vulnerability lifecycle status
- **Database Ready**: Fields already exist in Prisma schema for storage

## Database Compatibility
- ✅ Prisma schema already includes these fields
- ✅ Repository methods already handle timing data
- ✅ No migration required

## Testing
- OSV API returns `published` and `modified` as ISO 8601 strings
- Service converts to Date objects for consistent handling
- Database storage maintains timing information for cached vulnerabilities